### PR TITLE
fixed db reference to allow sequlize store to initialize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "boilermaker",
+  "name": "seaBay",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const compression = require('compression')
 const session = require('express-session')
 const passport = require('passport')
 const SequelizeStore = require('connect-session-sequelize')(session.Store)
-const db = require('./db')
+const {db} = require('./db')
 const sessionStore = new SequelizeStore({db})
 const PORT = process.env.PORT || 8080
 const app = express()
@@ -57,7 +57,7 @@ const createApp = () => {
       secret: process.env.SESSION_SECRET || 'my best friend is Cody',
       store: sessionStore,
       resave: false,
-      saveUninitialized: false
+      saveUninitialized: false //NOTE: maybe make true for reasons that collin stated
     })
   )
   app.use(passport.initialize())


### PR DESCRIPTION
### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

Since we changed the export of db in the index file it wasnt referencing correctly in the call for Sequelize session store creation. fixed the import to reflect the change
