### PR TITLE
Fixing with router errors

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -5,14 +5,14 @@ import {Navbar} from './components'
 import Routes from './routes'
 import {fetchCart} from './store/viewCart.js'
 
-const App = () => {
+const App = props => {
   const dispatch = useDispatch()
   useEffect(() => {
     dispatch(fetchCart())
   }, [])
   return (
     <div>
-      <Navbar />
+      <Navbar {...props} />
       <Routes />
     </div>
   )

--- a/client/components/EditOrderForm.js
+++ b/client/components/EditOrderForm.js
@@ -111,4 +111,5 @@ OrderForm = connect(state => {
   }
 })(OrderForm)
 
-export default withRouter(OrderForm)
+//export default withRouter(OrderForm)
+export default OrderForm

--- a/client/components/EditUserForm.js
+++ b/client/components/EditUserForm.js
@@ -43,10 +43,10 @@ let UserForm = props => {
   )
 }
 
-UserForm = withRouter(
+/*UserForm = withRouter(
   reduxForm({
     form: 'editUser'
   })(UserForm)
-)
+)*/
 
-export default UserForm
+export default reduxForm({form: 'editUser'})(UserForm)

--- a/client/components/NotFound.js
+++ b/client/components/NotFound.js
@@ -48,4 +48,5 @@ const NotFound = function({history}) {
     </Segment>
   )
 }
-export default withRouter(NotFound)
+//export default withRouter(NotFound)
+export default NotFound

--- a/client/components/ViewCart.js
+++ b/client/components/ViewCart.js
@@ -82,7 +82,7 @@ const ViewCart = ({history, match}) => {
               ) : (
                 <div className="out-of-stock">
                   <div style={{color: 'red'}}>
-                    {`Sorry, this item is out of stock.`}
+                    Sorry, this item is out of stock.
                   </div>
                   <Button
                     onClick={() =>
@@ -121,4 +121,5 @@ const ViewCart = ({history, match}) => {
   )
 }
 
-export default withRouter(ViewCart)
+//export default withRouter(ViewCart)
+export default ViewCart

--- a/client/components/admin-dashboard.js
+++ b/client/components/admin-dashboard.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import {useSelector, useDispatch} from 'react-redux'
 import {Route, NavLink, matchPath} from 'react-router-dom'
-import ViewCart from './ViewCart'
+//import ViewCart from './ViewCart'
 import {Image, Tab, Header, Segment} from 'semantic-ui-react'
 
 import AllOrders from './orders/AllOrders'

--- a/client/components/auth-form.js
+++ b/client/components/auth-form.js
@@ -104,8 +104,11 @@ const mapDispatch = dispatch => {
   }
 }
 
-export const Login = withRouter(connect(mapLogin, mapDispatch)(AuthForm))
-export const Signup = withRouter(connect(mapSignup, mapDispatch)(AuthForm))
+/*export const Login = withRouter(connect(mapLogin, mapDispatch)(AuthForm))
+   export const Signup = withRouter(connect(mapSignup, mapDispatch)(AuthForm))*/
+
+export const Login = connect(mapLogin, mapDispatch)(AuthForm)
+export const Signup = connect(mapSignup, mapDispatch)(AuthForm)
 
 /**
  * PROP TYPES

--- a/client/components/checkoutForm.js
+++ b/client/components/checkoutForm.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import {useSelector} from 'react-redux'
-import {withRouter} from 'react-router-dom'
+//import {withRouter} from 'react-router-dom'
 import {Header, Divider, Segment} from 'semantic-ui-react'
-import _ from 'lodash'
-import faker from 'faker'
+//import _ from 'lodash'
+//import faker from 'faker'
 import ViewCart from './ViewCart'
 import axios from 'axios'
 import {toast} from 'react-toastify'
@@ -36,7 +36,7 @@ const checkoutForm = props => {
       <Segment>
         <Header as="h1">Review Your Order</Header>
       </Segment>
-      <ViewCart />
+      <ViewCart {...props} />
       <Divider />
       <StripeCheckout
         stripeKey="pk_test_0PmCoNYh2JkqkxmAX3FUAOPD00TQAUBVNb"
@@ -50,4 +50,5 @@ const checkoutForm = props => {
     </div>
   )
 }
-export default withRouter(checkoutForm)
+//export default withRouter(checkoutForm)
+export default checkoutForm

--- a/client/components/navbar.js
+++ b/client/components/navbar.js
@@ -46,4 +46,5 @@ const Navbar = ({history}) => {
   )
 }
 
-export default withRouter(Navbar)
+//export default withRouter(Navbar)
+export default Navbar

--- a/client/components/orders/AllOrders.js
+++ b/client/components/orders/AllOrders.js
@@ -61,7 +61,7 @@ const AllOrders = props => {
           return order.status === 'paid'
         })
         return (
-          <Route exact path="/home/all-orders/paid">
+          <Route exact path="/home/all-orders?status=paid">
             <Tab.Pane>
               <OrderList orders={paidOrders} />
             </Tab.Pane>
@@ -202,4 +202,5 @@ const AllOrders = props => {
   )
 }
 
-export default withRouter(AllOrders)
+//export default withRouter(AllOrders)
+export default AllOrders

--- a/client/components/orders/AllOrders.js
+++ b/client/components/orders/AllOrders.js
@@ -3,8 +3,14 @@ import {useDispatch, useSelector} from 'react-redux'
 import {Route, NavLink, matchPath, withRouter} from 'react-router-dom'
 import {fetchAllOrders} from '../../store/allOrders'
 import {Tab, Input, Pagination, Icon} from 'semantic-ui-react'
-import querystring from 'query-string'
+import {parse, stringify} from 'query-string'
 import OrderList from './OrderList'
+
+const sortbyOptions = [
+  {key: 'total', text: 'total', value: 'total'},
+  {key: 'id', text: 'id', value: 'id'},
+  {key: 'status', text: 'status', value: 'status'}
+]
 
 const AllOrders = props => {
   const orders = useSelector(state => state.allOrders)
@@ -14,11 +20,18 @@ const AllOrders = props => {
     dispatch(fetchAllOrders(location.search))
   }, [])
 
+  const handlePageChange = (event, data) => {
+    const queryObject = parse(location.search)
+    queryObject.page = data
+    const queryParams = stringify(queryObject)
+    history.push(`/home/all-orders/?${queryParams}`)
+  }
+
   const panes = [
     {
       menuItem: {
         as: NavLink,
-        to: '/home/all-orders/all',
+        to: '/home/all-orders?all',
         exact: true,
         key: 'allOrders',
         icon: 'unordered list',
@@ -26,7 +39,7 @@ const AllOrders = props => {
       },
       render: () => {
         return (
-          <Route exact path="/home/all-orders/all">
+          <Route exact path="/home/all-orders">
             <Tab.Pane>
               <OrderList orders={orders} all={true} />
             </Tab.Pane>
@@ -37,7 +50,7 @@ const AllOrders = props => {
     {
       menuItem: {
         as: NavLink,
-        to: '/home/all-orders/paid',
+        to: '/home/all-orders?status=paid',
         exact: true,
         key: 'paid',
         icon: 'money',
@@ -176,12 +189,20 @@ const AllOrders = props => {
     })
   })
 
+  const currentPage = parse(location.search).page || 1
+
   return (
     <Tab
       defaultActiveIndex={defaultActiveIndex}
       menu={{fluid: true, vertical: true, tabular: true}}
       panes={panes}
-    />
+    >
+      <Pagination
+        defaultActivePage={currentPage}
+        totalPages={2}
+        onPageChange={handlePageChange}
+      />
+    </Tab>
   )
 }
 

--- a/client/components/orders/ConfirmationPage.js
+++ b/client/components/orders/ConfirmationPage.js
@@ -36,6 +36,7 @@ const ConfirmationPage = props => {
   )
 }
 
-export default withRouter(ConfirmationPage)
+//export default withRouter(ConfirmationPage)
+export default ConfirmationPage
 
 // apply condition to useEffect in AddToCartButton (<<i think)

--- a/client/components/orders/OrderList.js
+++ b/client/components/orders/OrderList.js
@@ -3,7 +3,7 @@ import {Pagination, Icon, Header, Segment} from 'semantic-ui-react'
 import OrderModal from './OrderModal'
 import {parse, stringify} from 'query-string'
 import {NavLink, matchPath} from 'react-router-dom'
-import {withRouter} from 'react-router'
+//import {withRouter} from 'react-router'
 
 const OrderList = props => {
   const {all, orders} = props
@@ -48,7 +48,7 @@ const OrderList = props => {
             ) : null}
           </div>
           <div>
-            <OrderModal order={order} />
+            <OrderModal history={props.history} order={order} />
           </div>
         </div>
       ))}
@@ -65,4 +65,5 @@ const OrderList = props => {
   )
 }
 
-export default withRouter(OrderList)
+//export default withRouter(OrderList)
+export default OrderList

--- a/client/components/orders/OrderListing.js
+++ b/client/components/orders/OrderListing.js
@@ -13,7 +13,7 @@ const OrderListing = ({history, location}) => {
     return (
       <div>
         <h2>How did you get here?</h2>
-        <h3 onClick={() => history.back()}>Back</h3>
+        <h3 onClick={() => history.goBack()}>Back</h3>
       </div>
     )
   const isAdmin = user.status === 'admin'
@@ -34,7 +34,7 @@ const OrderListing = ({history, location}) => {
     return (
       <div>
         <h2>Unauthorized</h2>
-        <h3 onClick={() => history.back()}>Back</h3>
+        <h3 onClick={() => history.goBack()}>Back</h3>
       </div>
     )
   return (
@@ -113,4 +113,5 @@ const OrderListing = ({history, location}) => {
   )
 }
 
-export default withRouter(OrderListing)
+//export default withRouter(OrderListing)
+export default OrderListing

--- a/client/components/orders/OrderModal.js
+++ b/client/components/orders/OrderModal.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react'
 import {Table, Modal, Button, Icon, Divider, Label} from 'semantic-ui-react'
-import {withRouter} from 'react-router'
+//import {withRouter} from 'react-router'
 import {useDispatch, useSelector} from 'react-redux'
 import {centsToPrice} from '../../utilityMethods'
 import {changeOrder} from '../../store/singleOrder'
@@ -145,4 +145,5 @@ const OrderModal = ({order, history}) => {
   )
 }
 
-export default withRouter(OrderModal)
+//export default withRouter(OrderModal)
+export default OrderModal

--- a/client/components/orders/UserOrders.js
+++ b/client/components/orders/UserOrders.js
@@ -4,7 +4,7 @@ import {fetchUserOrders, resetUserOrders} from '../../store/userOrders'
 import {Segment, Item, Tab} from 'semantic-ui-react'
 import OrderList from './OrderList'
 
-const UserOrders = () => {
+const UserOrders = ({history}) => {
   const orders = useSelector(state => state.userOrders)
   const user = useSelector(state => state.user)
   const dispatch = useDispatch()
@@ -26,7 +26,7 @@ const UserOrders = () => {
         const allOrders = orders.filter(order => order.status !== 'in-cart')
         return (
           <Tab.Pane>
-            <OrderList orders={allOrders} all={true} />
+            <OrderList history={history} orders={allOrders} all={true} />
           </Tab.Pane>
         )
       }

--- a/client/components/products/AddProductForm.js
+++ b/client/components/products/AddProductForm.js
@@ -275,4 +275,5 @@ const AddProductForm = function(props) {
 //     }
 //   }
 // }
-export default withRouter(AddProductForm)
+//export default withRouter(AddProductForm)
+export default AddProductForm

--- a/client/components/products/ProductListing.js
+++ b/client/components/products/ProductListing.js
@@ -84,4 +84,5 @@ const ProductListing = props => {
   }
 }
 
-export default withRouter(ProductListing)
+//export default withRouter(ProductListing)
+export default ProductListing

--- a/client/components/products/UpdateProductForm.js
+++ b/client/components/products/UpdateProductForm.js
@@ -291,4 +291,5 @@ const UpdateProductForm = function(props) {
 //   }
 // }
 
-export default withRouter(UpdateProductForm)
+//export default withRouter(UpdateProductForm)
+export default UpdateProductForm

--- a/client/components/products/allProducts.js
+++ b/client/components/products/allProducts.js
@@ -157,4 +157,5 @@ const AllProducts = ({history, location}) => {
   )
 }
 
-export default withRouter(AllProducts)
+//export default withRouter(AllProducts)
+export default AllProducts

--- a/client/components/reviews/AddReview.js
+++ b/client/components/reviews/AddReview.js
@@ -152,4 +152,5 @@ const AddReview = props => {
   )
 }
 
-export default withRouter(AddReview)
+//export default withRouter(AddReview)
+export default AddReview

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -51,7 +51,7 @@ const UserHome = props => {
       render: () => (
         <Route exact path="/home/my-cart">
           <Tab.Pane>
-            <ViewCart cart={cart} />
+            <ViewCart {...props} cart={cart} />
           </Tab.Pane>
         </Route>
       )
@@ -68,7 +68,7 @@ const UserHome = props => {
       render: () => (
         <Route exact path="/home/my-orders">
           <Tab.Pane>
-            <UserOrders />
+            <UserOrders history={props.history} />
           </Tab.Pane>
         </Route>
       )
@@ -114,12 +114,6 @@ const UserHome = props => {
       exact: true
     })
   })
-  const adminDefaultActiveIndex = adminPanes.findIndex(pane => {
-    return !!matchPath(window.location.pathname, {
-      path: pane.menuItem.to,
-      exact: true
-    })
-  })
   return (
     <div>
       <Segment padded="very">
@@ -151,4 +145,5 @@ const UserHome = props => {
   )
 }
 
-export default withRouter(UserHome)
+//export default withRouter(UserHome)
+export default UserHome

--- a/client/components/user-home.js
+++ b/client/components/user-home.js
@@ -160,6 +160,12 @@ const UserHome = props => {
       exact: true
     })
   })
+  const adminDefaultActiveIndex = adminPanes.findIndex(pane => {
+    return !!matchPath(window.location.pathname, {
+      path: pane.menuItem.to,
+      exact: true
+    })
+  })
   return (
     <div>
       <Segment padded="very">
@@ -173,7 +179,10 @@ const UserHome = props => {
       <div className="user-home-tabs">
         <Tab defaultActiveIndex={defaultActiveIndex} panes={panes} />
         {isAdminStatus && (
-          <Tab defaultActiveIndex={defaultActiveIndex} panes={adminPanes} />
+          <Tab
+            defaultActiveIndex={adminDefaultActiveIndex}
+            panes={adminPanes}
+          />
         )}
       </div>
     </div>

--- a/client/components/users/SingleUser.js
+++ b/client/components/users/SingleUser.js
@@ -38,4 +38,5 @@ const SingleUser = props => {
   }
 }
 
-export default withRouter(SingleUser)
+//export default withRouter(SingleUser)
+export default SingleUser

--- a/client/components/users/Verified.js
+++ b/client/components/users/Verified.js
@@ -18,4 +18,5 @@ const Verified = function({history, location}) {
     </Container>
   )
 }
-export default withRouter(Verified)
+//export default withRouter(Verified)
+export default Verified

--- a/client/index.js
+++ b/client/index.js
@@ -12,7 +12,7 @@ import App from './app'
 ReactDOM.render(
   <Provider store={store}>
     <Router history={history}>
-      <App />
+      <App history={history} />
     </Router>
   </Provider>,
   document.getElementById('app')

--- a/client/routes.js
+++ b/client/routes.js
@@ -45,7 +45,7 @@ class Routes extends Component {
           exact
           path="/"
           render={props =>
-            user.id ? <UserHome {...props} /> : <AllProducts />
+            user.id ? <UserHome {...props} /> : <AllProducts {...props} />
           }
         />
         <Route exact path="/login" component={Login} />
@@ -55,29 +55,43 @@ class Routes extends Component {
         <Route
           path="/home"
           render={props =>
-            user.id ? <UserHome {...props} /> : <AllProducts />
+            user.id ? <UserHome {...props} /> : <AllProducts {...props} />
           }
         />
         <Route exact path="/view/user/:userId" component={SingleUser} />
 
         <Route
           path="/products"
-          render={() => <AllProducts key={location.search} />}
+          render={routeProps => (
+            <AllProducts {...routeProps} key={location.search} />
+          )}
         />
         <Route
           exact
           path="/view/product/:productId"
-          render={() => (
-            <ProductListing key={this.props.match.params.productId} />
+          render={routeProps => (
+            <ProductListing
+              key={this.props.match.params.productId}
+              {...routeProps}
+            />
           )}
         />
         <Route
           exact
           path="/orders/:orderId"
-          render={() => <OrderListing key={this.props.match.params.orderId} />}
+          render={routeProps => (
+            <OrderListing
+              key={this.props.match.params.orderId}
+              {...routeProps}
+            />
+          )}
         />
 
-        <Route exact path="/cart" render={() => <ViewCart />} />
+        <Route
+          exact
+          path="/cart"
+          render={routeProps => <ViewCart {...routeProps} />}
+        />
         <Route exact path="/cart/checkout" component={checkoutForm} />
         <Route
           exact

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -55,6 +55,7 @@ router.post('/checkout', async (req, res, next) => {
     }
   } catch (error) {
     console.error('Error', error)
+    next(error)
     // status = 'failure'
   }
 })


### PR DESCRIPTION
### Assignee Tasks

* [ ] added unit tests (or none needed)
* [ ] written relevant docs (or none needed)
* [x] referenced any relevant issues (or none exist)

_Components that were being exported as `withRouter(COMPONENT_NAME)` were throwing errors that `withRouter` "cannot be used outside of a `<Route />`". I worked around this by passing route props to components in `client/routes.js`, and passing `history` as props through those components that aren't handled by that `<Routes />` component._
